### PR TITLE
refactor: rename print variable and implement FBDarkOverlay frame

### DIFF
--- a/FastBinding.lua
+++ b/FastBinding.lua
@@ -13,12 +13,12 @@ function FastBinding.Enable(enable)
             local key = arg1;
             this:OnKeyDown(key);
         end);
-        Print.Chat("Enabled binding. Press ENTER or ESCAPE (with mouse out of action bars) to disable", "green");
+        FBPrint.Chat("Enabled binding. Press ENTER or ESCAPE (with mouse out of action bars) to disable", "green");
 
     else
         FastBinding.Frame:EnableKeyboard(nil);
         FastBinding.Frame:SetScript("OnKeyDown", nil);
-        Print.Chat("Disabled binding", "green");
+        FBPrint.Chat("Disabled binding", "green");
     end
 
 end
@@ -31,14 +31,14 @@ SlashCmdList["FASTBINDING"] = function(cmd)
     elseif(cmd == "debug") then
         if(FastBinding.Debug) then
             FastBinding.Debug = false
-            Print.Chat("Debug mode disabled")
+            FBPrint.Chat("Debug mode disabled")
         else
             FastBinding.Debug = true
-            Print.Chat("Debug mode enabled")
+            FBPrint.Chat("Debug mode enabled")
         end
     else
         if(FastBinding.Debug) then
-            Print.Debug(GetBindingAction(cmd))
+            FBPrint.Debug(GetBindingAction(cmd))
         end
     end
 end
@@ -57,11 +57,11 @@ FastBinding.Frame:SetScript("OnEvent", function()
     end
 
     if(FastBinding.Debug) then
-        Print.Chat("Loaded FastBinding as Debug", "yellow")
+        FBPrint.Chat("Loaded FastBinding as Debug", "yellow")
     else
-        Print.Chat("Loaded FastBinding", "yellow")
+        FBPrint.Chat("Loaded FastBinding", "yellow")
     end
-    Print.Chat("Detected '"..FastBinding.UIAddon.."' as UI Manager", "yellow")
+    FBPrint.Chat("Detected '"..FastBinding.UIAddon.."' as UI Manager", "yellow")
 
 end)
 
@@ -118,7 +118,7 @@ function FastBinding.SetKeyToActionButton(key, actionButton)
     end
 
     if SetBinding(key, bindingName, 1) then
-        Print.Chat("Set "..key.. " to "..bindingName);
+        FBPrint.Chat("Set "..key.. " to "..bindingName);
     end
 
     SaveBindings(2);
@@ -132,7 +132,7 @@ function FastBinding.ResetActionButton(actionButton)
     local usedKey = GetBindingKey(bindingName);
     if usedKey then
         SetBinding(usedKey);
-        Print.Chat("Removed "..usedKey.." from "..bindingName);
+        FBPrint.Chat("Removed "..usedKey.." from "..bindingName);
         SaveBindings(2);
     end
 

--- a/FastBinding.lua
+++ b/FastBinding.lua
@@ -2,10 +2,20 @@ FastBinding.Frame = CreateFrame("Frame");
 FastBinding.Enabled = false;
 FastBinding.UIAddon = "WoW Vanilla";
 
+local FBDarkOverlay
+
 -- Plugin enabler
 function FastBinding.Enable(enable)
 
     FastBinding.Enabled = enable;
+
+    if not FBDarkOverlay then
+        FBDarkOverlay = CreateFrame("Frame", "FBDarkOverlay", UIParent)
+        FBDarkOverlay:SetAllPoints(UIParent)
+        FBDarkOverlay.texture = FBDarkOverlay:CreateTexture()
+        FBDarkOverlay.texture:SetAllPoints(FBDarkOverlay)
+        FBDarkOverlay.texture:SetTexture(0, 0, 0, 0.7)
+    end
 
     if enable then
         FastBinding.Frame:EnableKeyboard(true);
@@ -14,11 +24,13 @@ function FastBinding.Enable(enable)
             this:OnKeyDown(key);
         end);
         FBPrint.Chat("Enabled binding. Press ENTER or ESCAPE (with mouse out of action bars) to disable", "green");
+        FBDarkOverlay:Show()
 
     else
         FastBinding.Frame:EnableKeyboard(nil);
         FastBinding.Frame:SetScript("OnKeyDown", nil);
         FBPrint.Chat("Disabled binding", "green");
+        FBDarkOverlay:Hide()
     end
 
 end

--- a/UIAddons/discord.lua
+++ b/UIAddons/discord.lua
@@ -11,9 +11,8 @@ function discord_IsActionButton(button)
 end
 
 function discord_GetBindingName(button)
-    Print.Debug(button)
+    FBPrint.Debug(button)
     local buttonName, buttonNumber = SplitActionButton(button);
     local bindingName = discord_BindingButtonsAliases[buttonName]
     return bindingName..buttonNumber;
 end
-

--- a/print.lua
+++ b/print.lua
@@ -1,6 +1,6 @@
-Print = {}
+FBPrint = {}
 
-Print.Colors = {
+FBPrint.Colors = {
     ["red"]    = {1.0, 0.0, 0.0},
     ["green"]  = {0.0, 1.0, 0.0},
     ["blue"]   = {0.0, 0.0, 1.0},
@@ -14,14 +14,14 @@ Print.Colors = {
     ["purple"] = {0.5, 0.0, 0.5},
 }
 
-function Print.Chat(msg, color)
-    local c = Print.Colors[color] or Print.Colors["gray"]
+function FBPrint.Chat(msg, color)
+    local c = FBPrint.Colors[color] or FBPrint.Colors["gray"]
 	ChatFrame1:AddMessage("FastBinding - "..msg, c[1], c[2], c[3])
 end
 
-function Print.Debug(msg, color)
+function FBPrint.Debug(msg, color)
     if FastBinding.Debug then
-        local c = Print.Colors[color] or Print.Colors["red"]
+        local c = FBPrint.Colors[color] or FBPrint.Colors["red"]
 	    ChatFrame1:AddMessage("[DEBUG] - "..msg, c[1], c[2], c[3])
     end
 end

--- a/uiAdapter.lua
+++ b/uiAdapter.lua
@@ -18,7 +18,7 @@ function IsAcceptedUIAddon(name)
 end
 
 function IsActionButton(button, uiAddon)
-    Print.Debug("Action button detected "..button);
+    FBPrint.Debug("Action button detected "..button);
     return AcceptedUIs[uiAddon]["IsActionButton"](button)
 end
 


### PR DESCRIPTION
This pull request includes two key changes:

- Renamed the global Print obj in print.lua to avoid conflicts and clarify usage.
- Implemented FBDarkOverlay frame(a dark overlay frame to dim screen background excluding Actionbar) creation on demand, deferring UI frame generation until toggled by user command. This optimizes memory usage and prevents unnecessary frame creation on addon load(There may not be a big difference though).

<img width="1817" height="831" alt="image" src="https://github.com/user-attachments/assets/e05f304b-50ca-4131-b16f-69a2a68f839f" />